### PR TITLE
Add mmd-load-greek-chinese.tex

### DIFF
--- a/mmd-load-greek-chinese.tex
+++ b/mmd-load-greek-chinese.tex
@@ -1,0 +1,16 @@
+\usepackage{xltxtra} % include fontspec
+
+% Use cm-unicode as default
+\setmainfont{CMU Serif}
+\setsansfont{CMU Sans Serif}
+\setmonofont{CMU Typewriter Text} % This one is not mature enough. Characters like "{}" is absent. In the future once it is mature, it would be better to set the main/sans/mono to CMU and NOT switching from Latin to Greek or vice versa.
+
+
+% Font Features
+\defaultfontfeatures[\rmfamily,\sffamily]{Ligatures=TeX}
+
+% XeCJK
+\usepackage{xeCJK} % Another way to support CJK
+\setCJKmainfont[BoldFont = * Bold, AutoFakeSlant]{Kaiti TC}
+\setCJKsansfont[AutoFakeSlant]{Microsoft YaHei}
+\setCJKmonofont[AutoFakeBold, AutoFakeSlant]{FangSong}


### PR DESCRIPTION
Only support Greek by CMU-Unicode and Chinese by XeCJK. The
ucharclasses used in mmd-load-unicode-related are too buggy. I can’t
get it work in the latest version of Mac OS and Mac TeX (in the past it
works…)
